### PR TITLE
Update FHE-RAM with latest Poulpy codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,20 +36,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
-name = "backend"
-version = "0.1.0"
-dependencies = [
- "criterion",
- "itertools 0.14.0",
- "rand",
- "rand_core",
- "rand_distr",
- "rug",
- "sampling",
- "utils",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,10 +48,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -126,22 +134,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "core"
-version = "0.1.0"
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
- "backend",
- "criterion",
- "itertools 0.14.0",
- "rand_distr",
- "rug",
- "sampling",
+ "cc",
 ]
 
 [[package]]
 name = "criterion"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
 dependencies = [
  "anes",
  "cast",
@@ -162,12 +167,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -211,18 +216,19 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "fhe-ram"
 version = "0.1.0"
 dependencies = [
- "backend",
- "core",
  "itertools 0.14.0",
+ "poulpy-backend",
+ "poulpy-core",
+ "poulpy-hal",
+ "poulpy-schemes",
  "rand_core",
- "sampling",
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "find-msvc-tools"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "getrandom"
@@ -254,15 +260,6 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -371,6 +368,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "poulpy-backend"
+version = "0.1.2"
+dependencies = [
+ "byteorder",
+ "cmake",
+ "criterion",
+ "itertools 0.14.0",
+ "once_cell",
+ "poulpy-hal",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rand_distr",
+ "rug",
+]
+
+[[package]]
+name = "poulpy-core"
+version = "0.1.1"
+dependencies = [
+ "byteorder",
+ "criterion",
+ "itertools 0.14.0",
+ "once_cell",
+ "poulpy-backend",
+ "poulpy-hal",
+ "rug",
+]
+
+[[package]]
+name = "poulpy-hal"
+version = "0.1.2"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cmake",
+ "criterion",
+ "itertools 0.14.0",
+ "once_cell",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rand_distr",
+ "rug",
+]
+
+[[package]]
+name = "poulpy-schemes"
+version = "0.1.1"
+dependencies = [
+ "byteorder",
+ "itertools 0.14.0",
+ "poulpy-backend",
+ "poulpy-core",
+ "poulpy-hal",
 ]
 
 [[package]]
@@ -528,15 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sampling"
-version = "0.1.0"
-dependencies = [
- "rand_chacha",
- "rand_core",
- "rand_distr",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,13 +646,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "utils"
-version = "0.1.0"
-dependencies = [
- "fnv",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-core = { path = "../poulpy/core" }
-backend = { path = "../poulpy/backend" }
-sampling = { path = "../poulpy/sampling" }
+poulpy-schemes = { path = "../poulpy/poulpy-schemes" }
+poulpy-core = { path = "../poulpy/poulpy-core" }
+poulpy-backend = { path = "../poulpy/poulpy-backend" }
+poulpy-hal = { path = "../poulpy/poulpy-hal" }
 rand_core = "0.9.3"
 itertools = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cargo run --release --example fhe-ram
 
 ```rust
 // Global public parameters (e.g. cryptographic parameters)
-let params = Parameters::new();
+let params = Parameters::default();
 
 // Word-size, i.e. how many chunks of K_PT bits a word is made of.
 // By default WORDSIZE=4 chunks of K_PT=8 bits, i.e. 32bit words.
@@ -124,7 +124,7 @@ let max_addr = params.max_addr();
 let (sk, evk) = gen_keys(&params);
 
 // Create a new FHE-RAM instance.
-let mut ram = Ram::new();
+let mut ram = Ram::default();
 
 // Encrypt an array of bytes of length WORDSIZE * MAX_ADDR as vector of GLWE.
 ram.encrypt_sk(&data, &sk);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,66 +1,82 @@
-use core::{AutomorphismKey, GLWECiphertext, GLWESecret, TensorKey};
 use std::collections::HashMap;
 
-use backend::{FFT64, Module, ScratchOwned};
-use sampling::source::{Source, new_seed};
+use poulpy_backend::FFT64Spqlios;
+use poulpy_core::layouts::{GGLWEAutomorphismKey, GGLWETensorKey, GLWECiphertext, GLWESecret};
+use poulpy_hal::{
+    api::{ScratchOwnedAlloc, ScratchOwnedBorrow},
+    layouts::{Module, ScratchOwned},
+    source::Source,
+};
+use rand_core::{OsRng, TryRngCore};
 
 use crate::parameters::Parameters;
 
 /// Struct storing the FHE evaluation keys for the read/write on FHE-RAM.
 pub struct EvaluationKeys {
-    pub(crate) auto_keys: HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>>,
-    pub(crate) tensor_key: TensorKey<Vec<u8>, FFT64>,
+    pub(crate) auto_keys: HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>>,
+    pub(crate) tensor_key: GGLWETensorKey<Vec<u8>>,
 }
 
 /// Generates a new set of [EvaluationKeys] along with the associated secret-key.
-pub fn gen_keys(params: &Parameters) -> (GLWESecret<Vec<u8>, FFT64>, EvaluationKeys) {
-    let module: &Module<FFT64> = &params.module();
+pub fn gen_keys(params: &Parameters) -> (GLWESecret<Vec<u8>>, EvaluationKeys) {
+    let module: &Module<FFT64Spqlios> = params.module();
     let basek: usize = params.basek();
     let k_evk: usize = params.k_evk();
     let rows: usize = params.rows_addr();
     let rank: usize = params.rank();
     let digits: usize = params.digits();
 
-    let mut source_1: Source = Source::new(new_seed());
-    let mut source_2: Source = Source::new(new_seed());
+    let mut root = [0u8; 32];
+    OsRng.try_fill_bytes(&mut root).unwrap();
 
-    let mut scratch: ScratchOwned = ScratchOwned::new(
-        AutomorphismKey::generate_from_sk_scratch_space(module, basek, k_evk, rank)
-            | AutomorphismKey::generate_from_sk_scratch_space(module, basek, k_evk, rank)
-            | TensorKey::generate_from_sk_scratch_space(module, basek, k_evk, rank),
+    let mut source: Source = Source::new(root);
+
+    let seed_xs = source.new_seed();
+    let mut source_xs = Source::new(seed_xs);
+
+    let seed_xa = source.new_seed();
+    let mut source_xa = Source::new(seed_xa);
+
+    let seed_xe = source.new_seed();
+    let mut source_xe = Source::new(seed_xe);
+
+    let mut scratch: ScratchOwned<FFT64Spqlios> = ScratchOwned::alloc(
+        GGLWEAutomorphismKey::encrypt_sk_scratch_space(module, basek, k_evk, rank)
+            | GGLWETensorKey::encrypt_sk_scratch_space(module, basek, k_evk, rank),
     );
 
-    let mut sk: GLWESecret<Vec<u8>, FFT64> = GLWESecret::alloc(module, params.rank());
-    sk.fill_ternary_prob(&module, params.xs(), &mut source_1);
+    let mut sk: GLWESecret<Vec<u8>> = GLWESecret::alloc(module.n(), params.rank());
+    sk.fill_ternary_prob(params.xs(), &mut source_xs);
 
-    let gal_els: Vec<i64> = GLWECiphertext::trace_galois_elements(&module);
+    let gal_els: Vec<i64> = GLWECiphertext::trace_galois_elements(module);
     let auto_keys = HashMap::from_iter(gal_els.iter().map(|gal_el| {
-        let mut key: AutomorphismKey<Vec<u8>, FFT64> =
-            AutomorphismKey::alloc(&module, basek, k_evk, rows, digits, rank);
-        key.generate_from_sk(
-            &module,
+        let mut key: GGLWEAutomorphismKey<Vec<u8>> =
+            GGLWEAutomorphismKey::alloc(module.n(), basek, k_evk, rows, digits, rank);
+        key.encrypt_sk(
+            module,
             *gal_el,
             &sk,
-            &mut source_1,
-            &mut source_2,
-            params.xe(),
+            &mut source_xa,
+            &mut source_xe,
             scratch.borrow(),
         );
         (*gal_el, key)
     }));
 
-    let mut tensor_key = TensorKey::alloc(module, basek, k_evk, rows, digits, rank);
-    tensor_key.generate_from_sk(
+    let mut tensor_key = GGLWETensorKey::alloc(module.n(), basek, k_evk, rows, digits, rank);
+    tensor_key.encrypt_sk(
         module,
         &sk,
-        &mut source_1,
-        &mut source_2,
-        params.xe(),
+        &mut source_xa,
+        &mut source_xe,
         scratch.borrow(),
     );
 
-    (sk, EvaluationKeys {
-        auto_keys,
-        tensor_key,
-    })
+    (
+        sk,
+        EvaluationKeys {
+            auto_keys,
+            tensor_key,
+        },
+    )
 }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,4 +1,5 @@
-use backend::{FFT64, Module};
+use poulpy_backend::FFT64Spqlios;
+use poulpy_hal::{api::ModuleNew, layouts::Module};
 
 const LOG_N: usize = 12;
 const BASEK: usize = 20;
@@ -15,19 +16,19 @@ const MAX_ADDR: usize = 1 << 18;
 const DIGITS: usize = 1;
 
 pub struct Parameters {
-    module: Module<FFT64>, // FFT/NTT tables.
-    basek: usize,          // Torus 2^{-k} decomposition.
-    digits: usize,         // Digits of GGLWE/GGSW product
-    rank: usize,           // GLWE/GGLWE/GGSW rank.
-    k_pt: usize,           // Ram plaintext (GLWE) Torus precision.
-    k_ct: usize,           // Ram ciphertext (GLWE) Torus precision.
-    k_addr: usize,         // Ram address (GGSW) Torus precision.
-    k_evk: usize,          // Ram evaluation keys (GGLWE) Torus precision
-    xs: f64,               // Secret-key distribution.
-    xe: f64,               // Noise standard deviation.
-    max_addr: usize,       // Maximum supported address.
-    decomp_n: Vec<u8>,     // Digit decomposition of N.
-    word_size: usize,      // Digit decomposition of a Ram word.
+    module: Module<FFT64Spqlios>, // FFT/NTT tables.
+    basek: usize,                 // Torus 2^{-k} decomposition.
+    digits: usize,                // Digits of GGLWE/GGSW product
+    rank: usize,                  // GLWE/GGLWE/GGSW rank.
+    k_pt: usize,                  // Ram plaintext (GLWE) Torus precision.
+    k_ct: usize,                  // Ram ciphertext (GLWE) Torus precision.
+    k_addr: usize,                // Ram address (GGSW) Torus precision.
+    k_evk: usize,                 // Ram evaluation keys (GGLWE) Torus precision
+    xs: f64,                      // Secret-key distribution.
+    xe: f64,                      // Noise standard deviation.
+    max_addr: usize,              // Maximum supported address.
+    decomp_n: Vec<u8>,            // Digit decomposition of N.
+    word_size: usize,             // Digit decomposition of a Ram word.
 }
 
 impl Parameters {
@@ -35,7 +36,7 @@ impl Parameters {
         assert!(DECOMP_N.iter().sum::<u8>() == LOG_N as u8);
 
         Self {
-            module: Module::<FFT64>::new(1 << LOG_N),
+            module: Module::<FFT64Spqlios>::new(1 << LOG_N),
             basek: BASEK,
             digits: DIGITS,
             rank: RANK,
@@ -55,7 +56,7 @@ impl Parameters {
         self.max_addr
     }
 
-    pub fn module(&self) -> &Module<FFT64> {
+    pub fn module(&self) -> &Module<FFT64Spqlios> {
         &self.module
     }
 
@@ -100,14 +101,20 @@ impl Parameters {
     }
 
     pub(crate) fn rows_ct(&self) -> usize {
-        (self.k_ct() + self.basek() - 1) / self.basek()
+        self.k_ct().div_ceil(self.basek())
     }
 
     pub(crate) fn rows_addr(&self) -> usize {
-        (self.k_addr() + self.basek() - 1) / self.basek()
+        self.k_addr().div_ceil(self.basek())
     }
 
     pub(crate) fn decomp_n(&self) -> Vec<u8> {
         self.decomp_n.clone()
+    }
+}
+
+impl Default for Parameters {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/ram.rs
+++ b/src/ram.rs
@@ -1,12 +1,23 @@
-use core::{
-    AutomorphismKey, GLWECiphertext, GLWEOps, GLWEPlaintext, GLWESecret, ScratchCore, StreamPacker,
-    TensorKey,
-};
 use std::collections::HashMap;
 
-use backend::{Encoding, FFT64, Module, Scratch, ScratchOwned};
+use poulpy_backend::FFT64Spqlios;
+use poulpy_core::{
+    GLWEOperations, GLWEPacker, TakeGLWECt,
+    layouts::{
+        GGLWEAutomorphismKey, GGLWETensorKey, GLWECiphertext, GLWEPlaintext, GLWESecret,
+        prepared::{
+            GGLWEAutomorphismKeyPrepared, GGLWETensorKeyPrepared, GLWESecretPrepared, PrepareAlloc,
+        },
+    },
+};
+use poulpy_hal::{
+    api::{ScratchOwnedAlloc, ScratchOwnedBorrow},
+    layouts::{Data, Module, Scratch, ScratchOwned},
+    source::Source,
+};
+
 use itertools::izip;
-use sampling::source::{Source, new_seed};
+use rand_core::{OsRng, TryRngCore};
 
 use crate::{
     address::{Address, Coordinate},
@@ -19,14 +30,14 @@ use crate::{
 pub struct Ram {
     pub(crate) params: Parameters,
     pub(crate) subrams: Vec<SubRam>,
-    pub(crate) scratch: ScratchOwned,
+    pub(crate) scratch: ScratchOwned<FFT64Spqlios>,
 }
 
 impl Ram {
     /// Instantiates a new [Ram].
     pub fn new() -> Self {
-        let params: Parameters = Parameters::new();
-        let scratch: ScratchOwned = ScratchOwned::new(Self::scratch_bytes(&params));
+        let params: Parameters = Parameters::default();
+        let scratch: ScratchOwned<FFT64Spqlios> = ScratchOwned::alloc(Self::scratch_bytes(&params));
         Self {
             subrams: (0..params.word_size())
                 .map(|_| SubRam::alloc(&params))
@@ -38,7 +49,7 @@ impl Ram {
 
     /// Scratch space size required by the [Ram].
     pub(crate) fn scratch_bytes(params: &Parameters) -> usize {
-        let module: &Module<FFT64> = params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let k_ct: usize = params.k_ct();
         let k_evk: usize = params.k_evk();
         let basek: usize = params.basek();
@@ -47,26 +58,26 @@ impl Ram {
 
         let enc_sk: usize = GLWECiphertext::encrypt_sk_scratch_space(module, basek, k_ct);
         let coordinate_product: usize = Coordinate::product_scratch_space(params);
-        let packing: usize = StreamPacker::scratch_space(module, basek, k_ct, k_evk, digits, rank);
+        let packing: usize = GLWEPacker::scratch_space(module, basek, k_ct, k_evk, digits, rank);
         let trace: usize =
             GLWECiphertext::trace_inplace_scratch_space(module, basek, k_ct, k_evk, digits, rank);
-        let ct: usize = GLWECiphertext::bytes_of(module, basek, k_ct, rank);
+        let ct: usize = GLWECiphertext::bytes_of(module.n(), basek, k_ct, rank);
         let inv_addr: usize = Coordinate::invert_scratch_space(params);
 
         let read: usize = coordinate_product | trace | packing;
-        let write: usize = coordinate_product | ct + trace | inv_addr;
+        let write: usize = coordinate_product | (ct + trace) | inv_addr;
 
         enc_sk | read | write
     }
 
-    /// Initialize the FHE-[Ram] with provided values (encrypted inder the provided secret).
-    pub fn encrypt_sk(&mut self, data: &[u8], sk: &GLWESecret<Vec<u8>, FFT64>) {
+    /// Initialize the FHE-[Ram] with the provided values (encrypted under the provided secret).
+    pub fn encrypt_sk(&mut self, data: &[u8], sk: &GLWESecret<Vec<u8>>) {
         let params: &Parameters = &self.params;
         let max_addr: usize = params.max_addr();
         let ram_chunks: usize = params.word_size();
 
         assert!(
-            data.len() % ram_chunks == 0,
+            data.len().is_multiple_of(ram_chunks),
             "invalid data: data.len()%ram_chunks={} != 0",
             data.len() % ram_chunks,
         );
@@ -78,14 +89,14 @@ impl Ram {
             max_addr
         );
 
-        let scratch: &mut Scratch = self.scratch.borrow();
+        let scratch: &mut Scratch<FFT64Spqlios> = self.scratch.borrow();
 
         let mut data_split: Vec<u8> = vec![0u8; max_addr];
         (0..ram_chunks).for_each(|i| {
             data_split.iter_mut().enumerate().for_each(|(j, x)| {
-                *x = data[j + i];
+                *x = data[j * ram_chunks + i];
             });
-            self.subrams[i].encrypt_sk(params, &data_split, &sk, scratch);
+            self.subrams[i].encrypt_sk(params, &data_split, sk, scratch);
         });
     }
 
@@ -98,7 +109,7 @@ impl Ram {
         keys: &EvaluationKeys,
     ) -> Vec<GLWECiphertext<Vec<u8>>> {
         assert!(
-            self.subrams.len() != 0,
+            !self.subrams.is_empty(),
             "unitialized memory: self.data.len()=0"
         );
 
@@ -124,7 +135,7 @@ impl Ram {
         keys: &EvaluationKeys,
     ) -> Vec<GLWECiphertext<Vec<u8>>> {
         assert!(
-            self.subrams.len() != 0,
+            !self.subrams.is_empty(),
             "unitialized memory: self.data.len()=0"
         );
 
@@ -143,28 +154,34 @@ impl Ram {
 
     /// Writes w to the [Ram]. Requires that [Self::read_prepare_write] was
     /// called beforehand.
-    pub fn write<DataW: AsRef<[u8]>>(
+    pub fn write<DataW: Data + AsRef<[u8]>>(
         &mut self,
-        w: &Vec<GLWECiphertext<DataW>>, // Must encrypt [w, 0, 0, ..., 0];
+        w: &[GLWECiphertext<DataW>], // Must encrypt [w, 0, 0, ..., 0];
         address: &Address,
         keys: &EvaluationKeys,
     ) {
         assert!(w.len() == self.subrams.len());
 
         let params: &Parameters = &self.params;
-        let module: &Module<FFT64> = &params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let basek: usize = params.basek();
         let rank: usize = params.rank();
         let digits: usize = params.digits();
 
-        let scratch: &mut Scratch = self.scratch.borrow();
-        let auto_keys: &HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>> = &keys.auto_keys;
-        let tensor_key: &TensorKey<Vec<u8>, FFT64> = &keys.tensor_key;
+        let scratch: &mut Scratch<FFT64Spqlios> = self.scratch.borrow();
+        let auto_keys: &HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>> = &keys.auto_keys;
+        let tensor_key: &GGLWETensorKey<Vec<u8>> = &keys.tensor_key;
 
         // Overwrites the coefficient that was read: to_write_on = to_write_on - TRACE(to_write_on) + w
         self.subrams.iter_mut().enumerate().for_each(|(i, subram)| {
             subram.write_first_step(params, &w[i], address.n2(), auto_keys, scratch);
         });
+
+        let auto_key_prepared: GGLWEAutomorphismKeyPrepared<Vec<u8>, FFT64Spqlios> =
+            auto_keys.get(&-1).unwrap().prepare_alloc(module, scratch);
+
+        let tensor_key_prepared: GGLWETensorKeyPrepared<Vec<u8>, FFT64Spqlios> =
+            tensor_key.prepare_alloc(module, scratch);
 
         for i in (0..address.n2() - 1).rev() {
             // Index polynomial X^{i}
@@ -177,7 +194,7 @@ impl Ram {
                 address.rows(),
                 rank,
                 digits,
-                &coordinate.base1d.clone(),
+                &coordinate.base1d,
             ); // DODO ALLOC FROM SCRATCH SPACE
 
             inv_coordinate.base1d = coordinate.base1d.clone();
@@ -186,8 +203,8 @@ impl Ram {
             inv_coordinate.invert(
                 module,
                 coordinate,
-                auto_keys.get(&-1).unwrap(),
-                tensor_key,
+                &auto_key_prepared,
+                &tensor_key_prepared,
                 scratch,
             );
 
@@ -212,8 +229,8 @@ impl Ram {
         inv_coordinate.invert(
             module,
             coordinate,
-            auto_keys.get(&-1).unwrap(),
-            tensor_key,
+            &auto_key_prepared,
+            &tensor_key_prepared,
             scratch,
         );
 
@@ -223,17 +240,23 @@ impl Ram {
     }
 }
 
+impl Default for Ram {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// [SubRam] stores a digit of the word.
 pub(crate) struct SubRam {
     data: Vec<GLWECiphertext<Vec<u8>>>,
     tree: Vec<Vec<GLWECiphertext<Vec<u8>>>>,
-    packer: StreamPacker,
+    packer: GLWEPacker,
     state: bool,
 }
 
 impl SubRam {
     pub fn alloc(params: &Parameters) -> Self {
-        let module: &Module<FFT64> = &params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
         let rank: usize = params.rank();
@@ -243,11 +266,11 @@ impl SubRam {
         let max_addr_split: usize = params.max_addr(); // u8 -> u32
 
         if max_addr_split > n {
-            let mut size: usize = (max_addr_split + n - 1) / n;
+            let mut size: usize = max_addr_split.div_ceil(n);
             while size != 1 {
-                size = (size + n - 1) / n;
+                size = size.div_ceil(n);
                 let tmp: Vec<GLWECiphertext<Vec<u8>>> = (0..size)
-                    .map(|_| GLWECiphertext::alloc(module, basek, k_ct, rank))
+                    .map(|_| GLWECiphertext::alloc(module.n(), basek, k_ct, rank))
                     .collect();
                 tree.push(tmp);
             }
@@ -255,8 +278,8 @@ impl SubRam {
 
         Self {
             data: Vec::new(),
-            tree: tree,
-            packer: StreamPacker::new(module, 0, basek, k_ct, rank),
+            tree,
+            packer: GLWEPacker::new(module.n(), 0, basek, k_ct, rank),
             state: false,
         }
     }
@@ -265,38 +288,47 @@ impl SubRam {
         &mut self,
         params: &Parameters,
         data: &[u8],
-        sk: &GLWESecret<Vec<u8>, FFT64>,
-        scratch: &mut Scratch,
+        sk: &GLWESecret<Vec<u8>>,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) {
-        let module: &Module<FFT64> = &params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let k_pt: usize = params.k_pt();
-        let sigma: f64 = params.xe();
         let rank: usize = params.rank();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
 
-        let mut source_xa: Source = Source::new(new_seed());
-        let mut source_xe: Source = Source::new(new_seed());
+        let mut root = [0u8; 32];
+        OsRng.try_fill_bytes(&mut root).unwrap();
 
-        let mut pt: GLWEPlaintext<Vec<u8>> = GLWEPlaintext::alloc(module, basek, k_pt);
+        let mut source: Source = Source::new(root);
+
+        let seed_xa = source.new_seed();
+        let mut source_xa = Source::new(seed_xa);
+
+        let seed_xe = source.new_seed();
+        let mut source_xe = Source::new(seed_xe);
+
+        let mut pt: GLWEPlaintext<Vec<u8>> = GLWEPlaintext::alloc(module.n(), basek, k_pt);
         let mut data_i64: Vec<i64> = vec![0i64; module.n()];
 
         self.data = data
             .chunks(module.n())
             .map(|chunk| {
                 let mut ct: GLWECiphertext<Vec<u8>> =
-                    GLWECiphertext::alloc(module, basek, k_ct, rank);
+                    GLWECiphertext::alloc(module.n(), basek, k_ct, rank);
                 izip!(data_i64.iter_mut(), chunk.iter())
                     .for_each(|(xi64, xu8)| *xi64 = *xu8 as i64);
                 data_i64[chunk.len()..].iter_mut().for_each(|x| *x = 0);
-                pt.data.encode_vec_i64(0, basek, k_pt, &data_i64, 8);
-                ct.encrypt_sk::<_, Vec<u8>>(
+                pt.data.encode_vec_i64(basek, 0, k_pt, &data_i64, 8);
+                let sk_prepared: GLWESecretPrepared<Vec<u8>, FFT64Spqlios> =
+                    sk.prepare_alloc(module, scratch);
+
+                ct.encrypt_sk(
                     module,
                     &pt,
-                    &sk,
+                    &sk_prepared,
                     &mut source_xa,
                     &mut source_xe,
-                    sigma,
                     scratch,
                 );
                 ct
@@ -308,34 +340,34 @@ impl SubRam {
         &mut self,
         params: &Parameters,
         address: &Address,
-        auto_keys: &HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>>,
-        scratch: &mut Scratch,
+        auto_keys: &HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>>,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) -> GLWECiphertext<Vec<u8>> {
-        assert_eq!(
-            self.state, false,
+        assert!(
+            !self.state,
             "invalid call to Memory.read: internal state is true -> requires calling Memory.write"
         );
 
-        let module: &Module<FFT64> = &params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let log_n: usize = module.log_n();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
         let rank: usize = params.rank();
-        let packer: &mut StreamPacker = &mut self.packer;
+        let packer: &mut GLWEPacker = &mut self.packer;
 
         let mut results: Vec<GLWECiphertext<Vec<u8>>> = Vec::new();
-        let mut tmp_ct: GLWECiphertext<Vec<u8>> = GLWECiphertext::alloc(module, basek, k_ct, rank);
+        let mut tmp_ct: GLWECiphertext<Vec<u8>> =
+            GLWECiphertext::alloc(module.n(), basek, k_ct, rank);
+        let auto_keys_prepared: HashMap<i64, GGLWEAutomorphismKeyPrepared<Vec<u8>, FFT64Spqlios>> =
+            auto_keys
+                .iter()
+                .map(|(g, k)| (*g, k.prepare_alloc(module, scratch)))
+                .collect();
 
         for i in 0..address.n2() {
             let coordinate: &Coordinate<Vec<u8>> = address.at(i);
-
-            let res_prev: &Vec<GLWECiphertext<Vec<u8>>>;
-
-            if i == 0 {
-                res_prev = &self.data
-            } else {
-                res_prev = &results
-            }
+            let res_prev: &Vec<GLWECiphertext<Vec<u8>>> =
+                if i == 0 { &self.data } else { &results };
 
             if i < address.n2() - 1 {
                 let mut result_next: Vec<GLWECiphertext<Vec<u8>>> = Vec::new();
@@ -346,31 +378,29 @@ impl SubRam {
 
                         if j_rev < chunk.len() {
                             coordinate.product(module, &mut tmp_ct, &chunk[j_rev], scratch);
-                            packer.add(module, &mut result_next, Some(&tmp_ct), auto_keys, scratch);
+                            packer.add(module, Some(&tmp_ct), &auto_keys_prepared, scratch);
                         } else {
                             packer.add(
                                 module,
-                                &mut result_next,
                                 None::<&GLWECiphertext<Vec<u8>>>,
-                                auto_keys,
+                                &auto_keys_prepared,
                                 scratch,
                             );
                         }
                     });
+                    let mut packed_ct = GLWECiphertext::alloc(module.n(), basek, k_ct, rank);
+                    packer.flush(module, &mut packed_ct);
+                    result_next.push(packed_ct);
                 }
 
-                packer.flush(module, &mut result_next, auto_keys, scratch);
-                packer.reset();
                 results = result_next;
+            } else if i == 0 {
+                coordinate.product(module, &mut tmp_ct, &self.data[0], scratch);
             } else {
-                if i == 0 {
-                    coordinate.product(module, &mut tmp_ct, &self.data[0], scratch);
-                } else {
-                    coordinate.product(module, &mut tmp_ct, &results[0], scratch);
-                }
+                coordinate.product(module, &mut tmp_ct, &results[0], scratch);
             }
         }
-        tmp_ct.trace_inplace(module, 0, log_n, auto_keys, scratch);
+        tmp_ct.trace_inplace(module, 0, log_n, &auto_keys_prepared, scratch);
         tmp_ct
     }
 
@@ -378,31 +408,34 @@ impl SubRam {
         &mut self,
         params: &Parameters,
         address: &Address,
-        auto_keys: &HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>>,
-        scratch: &mut Scratch,
+        auto_keys: &HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>>,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) -> GLWECiphertext<Vec<u8>> {
-        assert_eq!(
-            self.state, false,
+        assert!(
+            !self.state,
             "invalid call to Memory.read: internal state is true -> requires calling Memory.write"
         );
 
-        let module: &Module<FFT64> = &params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let log_n: usize = module.log_n();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
         let rank: usize = params.rank();
-        let packer: &mut StreamPacker = &mut self.packer;
+        let packer: &mut GLWEPacker = &mut self.packer;
+        let auto_keys_prepared: HashMap<i64, GGLWEAutomorphismKeyPrepared<Vec<u8>, FFT64Spqlios>> =
+            auto_keys
+                .iter()
+                .map(|(g, k)| (*g, k.prepare_alloc(module, scratch)))
+                .collect();
 
         for i in 0..address.n2() {
             let coordinate: &Coordinate<Vec<u8>> = address.at(i);
 
-            let res_prev: &mut Vec<GLWECiphertext<Vec<u8>>>;
-
-            if i == 0 {
-                res_prev = &mut self.data;
+            let res_prev: &mut Vec<GLWECiphertext<Vec<u8>>> = if i == 0 {
+                &mut self.data
             } else {
-                res_prev = &mut self.tree[i - 1];
-            }
+                &mut self.tree[i - 1]
+            };
 
             // Shift polynomial of the last iteration by X^{-i}
             res_prev.iter_mut().for_each(|poly| {
@@ -417,27 +450,20 @@ impl SubRam {
                     for i in 0..module.n() {
                         let i_rev: usize = reverse_bits_msb(i, log_n as u32);
                         if i_rev < chunk.len() {
-                            packer.add(
-                                module,
-                                &mut result_next,
-                                Some(&chunk[i_rev]),
-                                auto_keys,
-                                scratch,
-                            );
+                            packer.add(module, Some(&chunk[i_rev]), &auto_keys_prepared, scratch);
                         } else {
                             packer.add(
                                 module,
-                                &mut result_next,
                                 None::<&GLWECiphertext<Vec<u8>>>,
-                                auto_keys,
+                                &auto_keys_prepared,
                                 scratch,
                             );
                         }
                     }
+                    let mut packed_ct = GLWECiphertext::alloc(module.n(), basek, k_ct, rank);
+                    packer.flush(module, &mut packed_ct);
+                    result_next.push(packed_ct);
                 }
-
-                packer.flush(module, &mut result_next, auto_keys, scratch);
-                packer.reset();
 
                 // Stores the packed polynomial
                 izip!(self.tree[i].iter_mut(), result_next.iter()).for_each(|(a, b)| {
@@ -446,7 +472,7 @@ impl SubRam {
             }
         }
 
-        let mut res: GLWECiphertext<Vec<u8>> = GLWECiphertext::alloc(module, basek, k_ct, rank);
+        let mut res: GLWECiphertext<Vec<u8>> = GLWECiphertext::alloc(module.n(), basek, k_ct, rank);
 
         self.state = true;
         if address.n2() != 1 {
@@ -455,53 +481,64 @@ impl SubRam {
             res.copy(module, &self.data[0]);
         }
 
-        res.trace_inplace(module, 0, log_n, auto_keys, scratch);
+        res.trace_inplace(module, 0, log_n, &auto_keys_prepared, scratch);
         res
     }
 
-    fn write_first_step<DataW: AsRef<[u8]>>(
+    fn write_first_step<DataW: Data + AsRef<[u8]>>(
         &mut self,
         params: &Parameters,
         w: &GLWECiphertext<DataW>,
         n2: usize,
-        auto_keys: &HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>>,
-        scratch: &mut Scratch,
+        auto_keys: &HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>>,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) {
-        assert_eq!(
-            self.state, true,
+        assert!(
+            self.state,
             "invalid call to Memory.write: internal state is false -> requires calling Memory.read_prepare_write"
         );
 
-        let module: &Module<FFT64> = params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let log_n: usize = module.log_n();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
         let rank: usize = params.rank();
 
-        let to_write_on: &mut GLWECiphertext<Vec<u8>>;
+        let auto_keys_prepared: HashMap<i64, GGLWEAutomorphismKeyPrepared<Vec<u8>, FFT64Spqlios>> =
+            auto_keys
+                .iter()
+                .map(|(g, k)| (*g, k.prepare_alloc(module, scratch)))
+                .collect();
 
-        if n2 != 1 {
-            to_write_on = &mut self.tree.last_mut().unwrap()[0]
+        let to_write_on: &mut GLWECiphertext<Vec<u8>> = if n2 != 1 {
+            &mut self.tree.last_mut().unwrap()[0]
         } else {
-            to_write_on = &mut self.data[0];
-        }
+            &mut self.data[0]
+        };
 
-        let (mut tmp_a, scratch_1) = scratch.tmp_glwe_ct(module, basek, k_ct, rank);
-        tmp_a.trace::<Vec<u8>, _>(module, 0, log_n, to_write_on, auto_keys, scratch_1);
+        let (mut tmp_a, scratch_1) = scratch.take_glwe_ct(module.n(), basek, k_ct, rank);
+        tmp_a.trace::<Vec<u8>, _, _>(
+            module,
+            0,
+            log_n,
+            to_write_on,
+            &auto_keys_prepared,
+            scratch_1,
+        );
         to_write_on.sub_inplace_ab(module, &tmp_a);
         to_write_on.add_inplace(module, w);
         to_write_on.normalize_inplace(module, scratch);
     }
 
-    fn write_mid_step<DataCoordinate: AsRef<[u8]>>(
+    fn write_mid_step<DataCoordinate: Data + AsRef<[u8]>>(
         &mut self,
         step: usize,
         params: &Parameters,
         inv_coordinate: &Coordinate<DataCoordinate>,
-        auto_keys: &HashMap<i64, AutomorphismKey<Vec<u8>, FFT64>>,
-        scratch: &mut Scratch,
+        auto_keys: &HashMap<i64, GGLWEAutomorphismKey<Vec<u8>>>,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) {
-        let module: &Module<FFT64> = params.module();
+        let module: &Module<FFT64Spqlios> = params.module();
         let log_n: usize = module.log_n();
         let basek: usize = params.basek();
         let k_ct: usize = params.k_ct();
@@ -509,6 +546,12 @@ impl SubRam {
 
         let tree_hi: &mut Vec<GLWECiphertext<Vec<u8>>>; // Above level
         let tree_lo: &mut Vec<GLWECiphertext<Vec<u8>>>; // Current level
+
+        let auto_keys_prepared: HashMap<i64, GGLWEAutomorphismKeyPrepared<Vec<u8>, FFT64Spqlios>> =
+            auto_keys
+                .iter()
+                .map(|(g, k)| (*g, k.prepare_alloc(module, scratch)))
+                .collect();
 
         // Top of the tree is not stored in results.
         if step == 0 {
@@ -532,13 +575,28 @@ impl SubRam {
                 chunk.iter_mut().for_each(|ct_hi| {
                     // Zeroes the first coefficient of ct_hi
                     // ct_hi = [a, b, c, d] - TRACE([a, b, c, d]) = [0, b, c, d]
-                    let (mut tmp_a, scratch_1) = scratch.tmp_glwe_ct(module, basek, k_ct, rank);
-                    tmp_a.trace::<Vec<u8>, Vec<u8>>(module, 0, log_n, ct_hi, auto_keys, scratch_1);
+                    let (mut tmp_a, scratch_1) =
+                        scratch.take_glwe_ct(module.n(), basek, k_ct, rank);
+                    tmp_a.trace::<Vec<u8>, Vec<u8>, FFT64Spqlios>(
+                        module,
+                        0,
+                        log_n,
+                        ct_hi,
+                        &auto_keys_prepared,
+                        scratch_1,
+                    );
                     ct_hi.sub_inplace_ab(module, &tmp_a);
 
                     // Extract the first coefficient ct_lo
                     // tmp_a = TRACE([a, b, c, d]) -> [a, 0, 0, 0]
-                    tmp_a.trace::<Vec<u8>, Vec<u8>>(module, 0, log_n, ct_lo, auto_keys, scratch_1);
+                    tmp_a.trace::<Vec<u8>, Vec<u8>, FFT64Spqlios>(
+                        module,
+                        0,
+                        log_n,
+                        ct_lo,
+                        &auto_keys_prepared,
+                        scratch_1,
+                    );
 
                     // Adds extracted coefficient of ct_lo on ct_hi
                     // [a, 0, 0, 0] + [0, b, c, d]
@@ -546,16 +604,16 @@ impl SubRam {
                     ct_hi.normalize_inplace(module, scratch_1);
 
                     // Cyclic shift ct_lo by X^-1
-                    ct_lo.rotate_inplace(module, -1);
+                    ct_lo.rotate_inplace(module, -1, scratch_1);
                 })
             });
     }
 
-    fn write_last_step<DataCoordinate: AsRef<[u8]>>(
+    fn write_last_step<DataCoordinate: Data + AsRef<[u8]>>(
         &mut self,
-        module: &Module<FFT64>,
+        module: &Module<FFT64Spqlios>,
         inv_coordinate: &Coordinate<DataCoordinate>,
-        scratch: &mut Scratch,
+        scratch: &mut Scratch<FFT64Spqlios>,
     ) {
         // Apply the last reverse shift to the top of the tree.
         self.data.iter_mut().for_each(|ct_lo| {


### PR DESCRIPTION
This PR updates FHE-RAM to align with the latest Poulpy codebase after [phantomzone-org/poulpy#85](https://github.com/phantomzone-org/poulpy/pull/85) was merged.

### Changes
- Updated API usage to match Poulpy’s current interfaces.
- Verified local build and example run.

### Notes
- README left unchanged; performance/security values are inherited from upstream.
- Successfully built and tested locally on macOS.
